### PR TITLE
Added HumHub v1.10 versioning support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.2.3
+## Changed
+- Added Versioning Support (HumHub v1.10+) 
+
 ## 2.2.2
 ## Fixed
 - Fixed JWT

--- a/controllers/BackendController.php
+++ b/controllers/BackendController.php
@@ -120,7 +120,14 @@ class BackendController extends Controller
                     $newData = file_get_contents($data["url"]);
 
                     if (!empty($newData)) {
-                        $this->file->getStore()->setContent($newData);
+
+                        if (version_compare(Yii::$app->version, '1.10', '=>')) {
+                            // For HumHub from version 1.10 with versioning support
+                            $this->file->setStoredFileContent($newData);
+                        } else {
+                            // Older HumHub versions
+                            $this->file->getStore()->setContent($newData);
+                        }
 
                         if ($status != 'ForceSave') {
                             $newAttr = [

--- a/controllers/BackendController.php
+++ b/controllers/BackendController.php
@@ -121,7 +121,7 @@ class BackendController extends Controller
 
                     if (!empty($newData)) {
 
-                        if (version_compare(Yii::$app->version, '1.10', '=>')) {
+                        if (version_compare(Yii::$app->version, '1.10', '>=')) {
                             // For HumHub from version 1.10 with versioning support
                             $this->file->setStoredFileContent($newData);
                         } else {


### PR DESCRIPTION
With HumHub v1.10 versioning is supported. This PR switches to the new File API.