### PR TITLE
Feature/editing not ooxml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - connect to the demo server
 - trial period of 30 days for the demo server
 - transfer user region in conversion
+- editable extensions on the settings page
 
 ## 2.4.0
 ## Added

--- a/Module.php
+++ b/Module.php
@@ -172,16 +172,9 @@ class Module extends \humhub\components\Module
         return boolval($this->settings->get('forceSave'));
     }
 
-    public function addExtForEditing()
+    public function getforceEditTypes()
     {
-        $values = explode("," , $this->settings->get('forceEditTypes'));
-        $exts = array_combine($this->forceEditableExtensions, $values);
-        foreach($exts as $ext => $enabled) {
-            if($enabled) {
-                array_push($this->editableExtensions, $ext);
-            }
-        }
-        
+        return explode("," , $this->settings->get('forceEditTypes'));
     }
 
     public function getServerApiUrl(): string
@@ -223,9 +216,8 @@ class Module extends \humhub\components\Module
 
     public function canEdit($file)
     {
-        $this->addExtForEditing();
         $fileExtension = strtolower(FileHelper::getExtension($file));
-        return in_array($fileExtension, $this->editableExtensions);
+        return in_array($fileExtension, array_merge($this->getforceEditTypes(), $this->editableExtensions));
     }
 
     public function canConvert($file)

--- a/Module.php
+++ b/Module.php
@@ -162,6 +162,24 @@ class Module extends \humhub\components\Module
         return $this->settings->get('compactToolbar');
     }
 
+    public function addExtForEditing()
+    {
+        $exts = [
+            'csv' => boolval($this->settings->get('editCSV')),
+            'odp' => boolval($this->settings->get('editODP')),
+            'ods' => boolval($this->settings->get('editODP')),
+            'odt' => boolval($this->settings->get('editODT')),
+            'rtf' => boolval($this->settings->get('editRTF')),
+            'txt' => boolval($this->settings->get('editTXT'))
+        ];
+        foreach($exts as $ext => $enabled) {
+            if($enabled) {
+                array_push($this->editableExtensions, $ext);
+            }
+        }
+        
+    }
+
     public function getServerApiUrl(): string
     {
         return $this->getServerUrl() . '/web-apps/apps/api/documents/api.js';
@@ -201,6 +219,7 @@ class Module extends \humhub\components\Module
 
     public function canEdit($file)
     {
+        $this->addExtForEditing();
         $fileExtension = strtolower(FileHelper::getExtension($file));
         return in_array($fileExtension, $this->editableExtensions);
     }

--- a/Module.php
+++ b/Module.php
@@ -65,8 +65,8 @@ class Module extends \humhub\components\Module
      */
     public $editableExtensions = ['xlsx', 'ppsx', 'pptx', 'docx', 'docxf', 'oform' ];
     public $convertableExtensions = ['doc','odt','xls','ods','ppt','odp','txt','csv'];
+    public $forceEditableExtensions = ['csv', 'odp', 'ods', 'odt', 'rtf', 'txt'];
 
-    
     public $convertsTo = [
         'doc' => 'docx',
         'odt' => 'docx',
@@ -164,14 +164,8 @@ class Module extends \humhub\components\Module
 
     public function addExtForEditing()
     {
-        $exts = [
-            'csv' => boolval($this->settings->get('editCSV')),
-            'odp' => boolval($this->settings->get('editODP')),
-            'ods' => boolval($this->settings->get('editODP')),
-            'odt' => boolval($this->settings->get('editODT')),
-            'rtf' => boolval($this->settings->get('editRTF')),
-            'txt' => boolval($this->settings->get('editTXT'))
-        ];
+        $values = explode("," , $this->settings->get('forceEditTypes'));
+        $exts = array_combine($this->forceEditableExtensions, $values);
         foreach($exts as $ext => $enabled) {
             if($enabled) {
                 array_push($this->editableExtensions, $ext);

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -50,7 +50,8 @@ class AdminController extends Controller
                                         'serverApiUrl' => $serverApiUrl,
                                         'error' => $error,
                                         'version' => $version,
-                                        'trial' => $trial
+                                        'trial' => $trial,
+                                        'forceEditExt' => $this->module->forceEditableExtensions
                                       ]);
     }
 

--- a/controllers/BackendController.php
+++ b/controllers/BackendController.php
@@ -20,6 +20,7 @@ use humhub\modules\user\models\User;
 use humhub\components\Controller;
 use \humhub\components\Module;
 use \Firebase\JWT\JWT;
+use humhub\modules\file\libs\FileHelper;
 
 class BackendController extends Controller
 {
@@ -152,7 +153,22 @@ class BackendController extends Controller
                 case "Corrupted":
                 case "ForceSave":
 
-                    $newData = $this->module->request($data["url"])->getContent();
+                    $url = $data["url"];
+                    $originExt = strtolower(FileHelper::getExtension($this->file));
+                    $currentExt = strtolower($data['filetype']);
+
+                    if($originExt !== $currentExt) {
+                        $result = $this->module->convertService(
+                            $data["url"], 
+                            $currentExt, 
+                            $originExt, 
+                            $this->module->generateDocumentKey($this->file) . time(), 
+                            false
+                        );
+                        $url = $result['fileUrl'];
+                    }
+
+                    $newData = $this->module->request($url)->getContent();
 
                     if (!empty($newData)) {
 

--- a/messages/de/base.php
+++ b/messages/de/base.php
@@ -64,4 +64,7 @@ return [
     'Error when trying to connect ({error})' => 'Fehler beim Anschließen ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Mixed Active Content ist nicht möglich. HTTPS-Adresse für ONLYOFFICE Docs ist erforderlich.',
     'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Öffne die Datei zum Bearbeiten (aufgrund von Formateinschränkungen können die Daten beim Speichern in den Formaten aus der folgenden Liste verloren gehen)',
+    'Connect to demo ONLYOFFICE Docs server' => 'Verbindung zu Demo ONLYOFFICE Docs Server herstellen',
+    'This is a public test server, please do not use it for private sensitive data. The server will be available during a 30-day period.' => 'Dies ist ein öffentlicher Testserver. Bitte verwende beim Testen keine privaten sensiblen Daten. Der Server ist 30 Tage lang verfügbar.',
+    'The 30-day test period is over, you can no longer connect to demo ONLYOFFICE Docs server.' => 'Der 30-tägige Testzeitraum ist abgelaufen. Du kannst keine Verbindung mehr zu Demo ONLYOFFICE Docs Server herstellen.',
 ];

--- a/messages/de/base.php
+++ b/messages/de/base.php
@@ -63,4 +63,5 @@ return [
     'Display monochrome toolbar header' => 'Monochromen Kopfbereich der Symbolleiste anzeigen',
     'Error when trying to connect ({error})' => 'Fehler beim Anschließen ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Mixed Active Content ist nicht möglich. HTTPS-Adresse für ONLYOFFICE Docs ist erforderlich.',
+    'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Öffne die Datei zum Bearbeiten (aufgrund von Formateinschränkungen können die Daten beim Speichern in den Formaten aus der folgenden Liste verloren gehen)',
 ];

--- a/messages/fr/base.php
+++ b/messages/fr/base.php
@@ -64,4 +64,7 @@ return [
     'Error when trying to connect ({error})' => 'Erreur durant la tentative de connexion ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Le contenu mixte actif n\'est pas autorisé. Une adresse HTTPS pour le ONLYOFFICE Docs est requise',
     'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Ouvrir le fichier pour édition (en raison de restrictions de format, des données peuvent être perdues lors de l\'enregistrement dans les formats de la liste ci-dessous)',
+    'Connect to demo ONLYOFFICE Docs server' => 'Se connecter à la version démo de ONLYOFFICE Docs',
+    'This is a public test server, please do not use it for private sensitive data. The server will be available during a 30-day period.' => 'C’est un serveur public proposé à des fins de tests, veuillez ne pas l’utiliser pour vos données personnelles sensibles. Le serveur est disponible pendant 30 jours.',
+    'The 30-day test period is over, you can no longer connect to demo ONLYOFFICE Docs server.' => 'La période d’essai de 30 jours est expirée, vous n’êtes plus en mesure de vous connecter à la version démo de ONLYOFFICE Docs.',
 ];

--- a/messages/fr/base.php
+++ b/messages/fr/base.php
@@ -63,4 +63,5 @@ return [
     'Display monochrome toolbar header' => 'Afficher un en-tête monochrome de la barre d\'outils',
     'Error when trying to connect ({error})' => 'Erreur durant la tentative de connexion ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Le contenu mixte actif n\'est pas autorisé. Une adresse HTTPS pour le ONLYOFFICE Docs est requise',
+    'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Ouvrir le fichier pour édition (en raison de restrictions de format, des données peuvent être perdues lors de l\'enregistrement dans les formats de la liste ci-dessous)',
 ];

--- a/messages/it/base.php
+++ b/messages/it/base.php
@@ -64,4 +64,7 @@ return [
     'Error when trying to connect ({error})' => 'Errore durante il tentativo di connessione ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Il contenuto attivo misto non è consentito. È richiesto l\'indirizzo HTTPS per ONLYOFFICE Docs.',
     'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Apri il file per la modifica (a causa di restrizioni di formato, i dati potrebbero andare persi durante il salvataggio nei formati della lista sottostante)',
+    'Connect to demo ONLYOFFICE Docs server' => 'Collegati alla versione demo di ONLYOFFICE Docs',
+    'This is a public test server, please do not use it for private sensitive data. The server will be available during a 30-day period.'=> 'Questo è un server di prova pubblico, non utilizzarlo per dati sensibili privati. Il server sarà disponibile per un periodo di 30 giorni.',
+    'The 30-day test period is over, you can no longer connect to demo ONLYOFFICE Docs server.' => 'Il periodo di prova di 30 giorni è terminato; non è più possibile connettersi alla versione demo di ONLYOFFICE Docs.',
 ];

--- a/messages/it/base.php
+++ b/messages/it/base.php
@@ -63,4 +63,5 @@ return [
     'Display monochrome toolbar header' => 'Visualizza intestazione della barra degli strumenti monocromatica',
     'Error when trying to connect ({error})' => 'Errore durante il tentativo di connessione ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Il contenuto attivo misto non è consentito. È richiesto l\'indirizzo HTTPS per ONLYOFFICE Docs.',
+    'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Apri il file per la modifica (a causa di restrizioni di formato, i dati potrebbero andare persi durante il salvataggio nei formati della lista sottostante)',
 ];

--- a/messages/ja/base.php
+++ b/messages/ja/base.php
@@ -63,4 +63,5 @@ return [
     'Display monochrome toolbar header' => 'モノクローム・ツールバーヘッダーを表示する',
     'Error when trying to connect ({error})' => '接続時にエラーが発生しました ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'アクティブコンテンツの混在は許可されていません。ONLYOFFICE DocsにはHTTPSアドレスが必要です',
+    'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => '編集できるファイルフォーマット (フォーマットの制限により、以下のフォーマットを保存する時にデータが失われる可能性があります)',
 ];

--- a/messages/ja/base.php
+++ b/messages/ja/base.php
@@ -64,4 +64,7 @@ return [
     'Error when trying to connect ({error})' => '接続時にエラーが発生しました ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'アクティブコンテンツの混在は許可されていません。ONLYOFFICE DocsにはHTTPSアドレスが必要です',
     'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => '編集できるファイルフォーマット (フォーマットの制限により、以下のフォーマットを保存する時にデータが失われる可能性があります)',
+    'Connect to demo ONLYOFFICE Docs server' => 'ONLYOFFICE Docsのデモサーバーに接続する',
+    'This is a public test server, please do not use it for private sensitive data. The server will be available during a 30-day period.' => 'これはパブリックテストサーバーです。プライベートな機密データには使用しないでください。サーバーを30日間、利用できます。',
+    'The 30-day test period is over, you can no longer connect to demo ONLYOFFICE Docs server.' => '30日間のテスト期間が終了したら、ONLYOFFICE Docs デモサーバーには繋がらなくなります。',
 ];

--- a/messages/pl/base.php
+++ b/messages/pl/base.php
@@ -63,4 +63,5 @@ return [
     'Display monochrome toolbar header' => 'Wyświetl monochromatyczny nagłówek paska narzędzi',
     'Error when trying to connect ({error})' => 'Błąd przy próbie połączenia ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Aktywna Zawartość Mieszana nie jest dozwolona. Adres HTTPS jest wymagany dla ONLYOFFICE Docs.',
+    'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Otwórz plik do edycji (ze względu na ograniczenia formatów, dane mogą zostac utracone przy zapisie do formatów podanych poniżej)',
 ];

--- a/messages/pl/base.php
+++ b/messages/pl/base.php
@@ -64,4 +64,7 @@ return [
     'Error when trying to connect ({error})' => 'Błąd przy próbie połączenia ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Aktywna Zawartość Mieszana nie jest dozwolona. Adres HTTPS jest wymagany dla ONLYOFFICE Docs.',
     'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Otwórz plik do edycji (ze względu na ograniczenia formatów, dane mogą zostac utracone przy zapisie do formatów podanych poniżej)',
+    'Connect to demo ONLYOFFICE Docs server' => 'Połącz się z serwerem demo ONLYOFFICE Docs',
+    'This is a public test server, please do not use it for private sensitive data. The server will be available during a 30-day period.' => 'To jest publiczny testowy serwer, proszę nie używać go do prywatnych danych. Serwer będzie dostępny przez 30 dni.',
+    'The 30-day test period is over, you can no longer connect to demo ONLYOFFICE Docs server.' => 'Upłyneło 30 dni, nie możesz się już łączyć z serwerem demo.',
 ];

--- a/messages/pt_br/base.php
+++ b/messages/pt_br/base.php
@@ -64,4 +64,7 @@ return [
     'Error when trying to connect ({error})' => 'Erro ao tentar conectar ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Conteúdo Misto não é permitido. É necessário um endereço HTTPS para o ONLYOFFICE Docs.',
     'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Habilitar edição (devido à restrição dos formatos, dados podem ser perdidos ao salvar nos formatos abaixo)',
+    'Connect to demo ONLYOFFICE Docs server' => 'Conectar ao Servidor de demonstração do ONLYOFFICE Docs',
+    'This is a public test server, please do not use it for private sensitive data. The server will be available during a 30-day period.' => 'Este é um servidor de teste público, não o use para dados confidenciais. O servidor estará disponível por um período de 30 dias.',
+    'The 30-day test period is over, you can no longer connect to demo ONLYOFFICE Docs server.' => 'O período de teste de 30 dias acabou, você não pode mais se conectar ao Servidor de demonstração do ONLYOFFICE Docs',
 ];

--- a/messages/pt_br/base.php
+++ b/messages/pt_br/base.php
@@ -63,4 +63,5 @@ return [
     'Display monochrome toolbar header' => 'Exibir cabeçalho da barra de ferramentas monocromático',
     'Error when trying to connect ({error})' => 'Erro ao tentar conectar ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Conteúdo Misto não é permitido. É necessário um endereço HTTPS para o ONLYOFFICE Docs.',
+    'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Habilitar edição (devido à restrição dos formatos, dados podem ser perdidos ao salvar nos formatos abaixo)',
 ];

--- a/messages/ru/base.php
+++ b/messages/ru/base.php
@@ -65,4 +65,7 @@ return [
     'Error when trying to connect ({error})' => 'При попытке соединения возникла ошибка ({error})',
     'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Смешанное активное содержимое запрещено. Для ONLYOFFICE Docs необходимо использовать HTTPS-адрес.',
     'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Открыть файл на редактирование (из-за ограничений формата данные могут быть утеряны при сохранении в форматы из списка ниже)',
+    'Connect to demo ONLYOFFICE Docs server' => 'Подключиться к демонстрационному серверу ONLYOFFICE Docs',
+    'This is a public test server, please do not use it for private sensitive data. The server will be available during a 30-day period.' => 'Это публичный тестовый сервер, пожалуйста, не используйте его для личных конфиденциальных данных. Сервер будет доступен в течение 30 дней.',
+    'The 30-day test period is over, you can no longer connect to demo ONLYOFFICE Docs server.' => '30-дневный тестовый период закончен, вы больше не можете подключаться к демонстрационному серверу ONLYOFFICE Docs',
 ];

--- a/messages/ru/base.php
+++ b/messages/ru/base.php
@@ -63,5 +63,6 @@ return [
     'Display Help menu button' => 'Отображать кнопку справки',
     'Display monochrome toolbar header' => 'Отображать монохромный заголовок панели инструментов',
     'Error when trying to connect ({error})' => 'При попытке соединения возникла ошибка ({error})',
-    'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Смешанное активное содержимое запрещено. Для ONLYOFFICE Docs необходимо использовать HTTPS-адрес.'
+    'Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required.' => 'Смешанное активное содержимое запрещено. Для ONLYOFFICE Docs необходимо использовать HTTPS-адрес.',
+    'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)' => 'Открыть файл на редактирование (из-за ограничений формата данные могут быть утеряны при сохранении в форматы из списка ниже)',
 ];

--- a/models/ConfigureForm.php
+++ b/models/ConfigureForm.php
@@ -73,7 +73,7 @@ class ConfigureForm extends \yii\base\Model
             'jwtSecret' => Yii::t('OnlyofficeModule.base', 'JWT Secret'),
             'internalServerUrl' => Yii::t('OnlyofficeModule.base', 'ONLYOFFICE Docs address for internal requests from the server'),
             'storageUrl' => Yii::t('OnlyofficeModule.base', 'Server address for internal requests from ONLYOFFICE Docs'),
-            'demoServer' => Yii::t('OnlyofficeModule.base', 'Connect to demo server'),
+            'demoServer' => Yii::t('OnlyofficeModule.base', 'Connect to demo ONLYOFFICE Docs server'),
             'chat' => Yii::t('OnlyofficeModule.base', 'Display Chat menu button'),
             'compactHeader' => Yii::t('OnlyofficeModule.base', 'Display the header more compact'),
             'feedback' => Yii::t('OnlyofficeModule.base', 'Display Feedback & Support menu button'),
@@ -94,6 +94,7 @@ class ConfigureForm extends \yii\base\Model
             'jwtSecret' => Yii::t('OnlyofficeModule.base', 'JWT Secret key (leave blank to disable)'),
             'internalServerUrl' => Yii::t('OnlyofficeModule.base', 'e.g. http://documentserver'),
             'storageUrl' => Yii::t('OnlyofficeModule.base', 'e.g. http://storage'),
+            'demoServer' => Yii::t('OnlyofficeModule.base', 'This is a public test server, please do not use it for private sensitive data. The server will be available during a 30-day period.'),
         ];
     }
 

--- a/models/ConfigureForm.php
+++ b/models/ConfigureForm.php
@@ -29,12 +29,7 @@ class ConfigureForm extends \yii\base\Model
     public $compactToolbar;
     public $customLabel;
 
-    public $editCSV;
-    public $editODP;
-    public $editODS;
-    public $editODT;
-    public $editRTF;
-    public $editTXT;
+    public $forceEditTypes;
 
     /**
      * @inheritdoc
@@ -53,12 +48,7 @@ class ConfigureForm extends \yii\base\Model
             ['feedback', 'boolean'],
             ['help', 'boolean'],
             ['compactToolbar', 'boolean'],
-            ['editCSV', 'boolean'],
-            ['editODP', 'boolean'],
-            ['editODS', 'boolean'],
-            ['editODT', 'boolean'],
-            ['editRTF', 'boolean'],
-            ['editTXT', 'boolean'],
+            ['forceEditTypes', 'string'],
         ];
     }
 
@@ -111,12 +101,7 @@ class ConfigureForm extends \yii\base\Model
         $this->feedback = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('feedback');
         $this->help = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('help');
         $this->compactToolbar = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('compactToolbar');
-        $this->editCSV = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editCSV');
-        $this->editODP = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editODP');
-        $this->editODS = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editODS');
-        $this->editODT = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editODT');
-        $this->editRTF = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editRTF');
-        $this->editTXT = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editTXT');
+        $this->forceEditTypes = explode("," , Yii::$app->getModule('onlyoffice')->settings->get("forceEditTypes"));
 
         return true;
     }
@@ -133,13 +118,8 @@ class ConfigureForm extends \yii\base\Model
         Yii::$app->getModule('onlyoffice')->settings->set('compactHeader', $this->compactHeader);
         Yii::$app->getModule('onlyoffice')->settings->set('feedback', $this->feedback);
         Yii::$app->getModule('onlyoffice')->settings->set('help', $this->help);
-        Yii::$app->getModule('onlyoffice')->settings->set('compactToolbar', $this->compactToolbar);
-        Yii::$app->getModule('onlyoffice')->settings->set('editCSV', $this->editCSV);
-        Yii::$app->getModule('onlyoffice')->settings->set('editODP', $this->editODP);
-        Yii::$app->getModule('onlyoffice')->settings->set('editODS', $this->editODS);
-        Yii::$app->getModule('onlyoffice')->settings->set('editODT', $this->editODT);
-        Yii::$app->getModule('onlyoffice')->settings->set('editRTF', $this->editRTF);
-        Yii::$app->getModule('onlyoffice')->settings->set('editTXT', $this->editTXT);
+        Yii::$app->getModule('onlyoffice')->settings->set('compactToolbar', $this->compactToolbar); 
+        Yii::$app->getModule('onlyoffice')->settings->set("forceEditTypes", implode("," , $this->forceEditTypes));
 
         return true;
     }

--- a/models/ConfigureForm.php
+++ b/models/ConfigureForm.php
@@ -29,6 +29,13 @@ class ConfigureForm extends \yii\base\Model
     public $compactToolbar;
     public $customLabel;
 
+    public $editCSV;
+    public $editODP;
+    public $editODS;
+    public $editODT;
+    public $editRTF;
+    public $editTXT;
+
     /**
      * @inheritdoc
      */
@@ -46,6 +53,12 @@ class ConfigureForm extends \yii\base\Model
             ['feedback', 'boolean'],
             ['help', 'boolean'],
             ['compactToolbar', 'boolean'],
+            ['editCSV', 'boolean'],
+            ['editODP', 'boolean'],
+            ['editODS', 'boolean'],
+            ['editODT', 'boolean'],
+            ['editRTF', 'boolean'],
+            ['editTXT', 'boolean'],
         ];
     }
 
@@ -67,6 +80,7 @@ class ConfigureForm extends \yii\base\Model
             'help' => Yii::t('OnlyofficeModule.base', 'Display Help menu button'),
             'compactToolbar' => Yii::t('OnlyofficeModule.base', 'Display monochrome toolbar header'),
             'customLabel' => Yii::t('OnlyofficeModule.base', 'The customization section allows personalizing the editor interface'),
+            'editLabel' => Yii::t('OnlyofficeModule.base', 'Open the file for editing (due to format restrictions, the data might be lost when saving to the formats from the list below)'),
         ];
     }
     
@@ -96,6 +110,12 @@ class ConfigureForm extends \yii\base\Model
         $this->feedback = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('feedback');
         $this->help = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('help');
         $this->compactToolbar = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('compactToolbar');
+        $this->editCSV = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editCSV');
+        $this->editODP = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editODP');
+        $this->editODS = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editODS');
+        $this->editODT = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editODT');
+        $this->editRTF = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editRTF');
+        $this->editTXT = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('editTXT');
 
         return true;
     }
@@ -113,6 +133,12 @@ class ConfigureForm extends \yii\base\Model
         Yii::$app->getModule('onlyoffice')->settings->set('feedback', $this->feedback);
         Yii::$app->getModule('onlyoffice')->settings->set('help', $this->help);
         Yii::$app->getModule('onlyoffice')->settings->set('compactToolbar', $this->compactToolbar);
+        Yii::$app->getModule('onlyoffice')->settings->set('editCSV', $this->editCSV);
+        Yii::$app->getModule('onlyoffice')->settings->set('editODP', $this->editODP);
+        Yii::$app->getModule('onlyoffice')->settings->set('editODS', $this->editODS);
+        Yii::$app->getModule('onlyoffice')->settings->set('editODT', $this->editODT);
+        Yii::$app->getModule('onlyoffice')->settings->set('editRTF', $this->editRTF);
+        Yii::$app->getModule('onlyoffice')->settings->set('editTXT', $this->editTXT);
 
         return true;
     }

--- a/models/ConfigureForm.php
+++ b/models/ConfigureForm.php
@@ -105,7 +105,7 @@ class ConfigureForm extends \yii\base\Model
         $this->help = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('help');
         $this->compactToolbar = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('compactToolbar');
         $this->forceSave = (boolean)Yii::$app->getModule('onlyoffice')->settings->get('forceSave');
-        $this->forceEditTypes = explode("," , Yii::$app->getModule('onlyoffice')->settings->get("forceEditTypes"));
+        $this->forceEditTypes = $this->deserializeForceEditTypes();
 
         return true;
     }
@@ -124,9 +124,23 @@ class ConfigureForm extends \yii\base\Model
         Yii::$app->getModule('onlyoffice')->settings->set('help', $this->help);
         Yii::$app->getModule('onlyoffice')->settings->set('compactToolbar', $this->compactToolbar);
         Yii::$app->getModule('onlyoffice')->settings->set('forceSave', $this->forceSave);
-        Yii::$app->getModule('onlyoffice')->settings->set("forceEditTypes", implode("," , $this->forceEditTypes));
+        Yii::$app->getModule('onlyoffice')->settings->set("forceEditTypes", $this->serializeForceEditTypes());
 
         return true;
     }
 
+    public function deserializeForceEditTypes() {
+        $result = [];
+        foreach (explode(",", Yii::$app->getModule('onlyoffice')->settings->get("forceEditTypes") ?? "") as $ext) {
+            $result[$ext] = 1;
+        }
+        return $result;
+    }
+
+    public function serializeForceEditTypes() {
+        return implode(",", array_keys(array_filter($this->forceEditTypes, function ($ext) {
+                return $ext == true;
+            }
+        )));
+    }
 }

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -61,12 +61,11 @@ use yii\web\View;
 
         <div class="form-group">
             <?= Html::activeLabel($model,'editLabel', ['class' => 'control-label']); ?>
-            <?= $form->field($model, 'editCSV', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'csv']); ?>
-            <?= $form->field($model, 'editODP', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'odp']); ?>
-            <?= $form->field($model, 'editODS', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'ods']); ?>
-            <?= $form->field($model, 'editODT', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'odt']); ?>
-            <?= $form->field($model, 'editRTF', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'rtf']); ?>
-            <?= $form->field($model, 'editTXT', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'txt']); ?>
+            <?php 
+                foreach($forceEditExt as $key => $ext) {
+                    echo $form->field($model, 'forceEditTypes[' . $key . ']', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => $ext]);
+                }
+            ?>
         </div>
 
         <div class="form-group">

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -64,7 +64,7 @@ use yii\web\View;
             <?= Html::activeLabel($model,'editLabel', ['class' => 'control-label']); ?>
             <?php 
                 foreach($forceEditExt as $key => $ext) {
-                    echo $form->field($model, 'forceEditTypes[' . $key . ']', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => $ext]);
+                    echo $form->field($model, 'forceEditTypes[' . $ext . ']', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => $ext]);
                 }
             ?>
         </div>

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -60,6 +60,16 @@ use yii\web\View;
         </div>
 
         <div class="form-group">
+            <?= Html::activeLabel($model,'editLabel', ['class' => 'control-label']); ?>
+            <?= $form->field($model, 'editCSV', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'csv']); ?>
+            <?= $form->field($model, 'editODP', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'odp']); ?>
+            <?= $form->field($model, 'editODS', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'ods']); ?>
+            <?= $form->field($model, 'editODT', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'odt']); ?>
+            <?= $form->field($model, 'editRTF', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'rtf']); ?>
+            <?= $form->field($model, 'editTXT', ['options' => ['class' => 'checkbox-inline']])->checkbox(['label' => 'txt']); ?>
+        </div>
+
+        <div class="form-group">
             <?= Html::submitButton('Submit', ['class' => 'btn btn-primary', 'data-ui-loader' => '']) ?>
         </div>
 

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -97,6 +97,7 @@ use yii\web\View;
         $("#configureform-demoserver").closest("label").css({"cursor":"default", "opacity":"0.5"});
         $("#configureform-demoserver").attr("checked", false);
         $("#configureform-demoserver").attr("disabled", true);
+        $("#configureform-demoserver").closest("div").children()[2].innerText = "' . Yii::t("OnlyofficeModule.base", "The 30-day test period is over, you can no longer connect to demo ONLYOFFICE Docs server.") . '";
     ');
    } 
 ?>


### PR DESCRIPTION
Added the ability to open for editing non-OOXML formats: csv, odp, odt, ods, rtf, txt in the module settings.
Added translations for demo server.