### PR TITLE
Update using of JWT methods `encode` and `decode`

### DIFF
--- a/controllers/BackendController.php
+++ b/controllers/BackendController.php
@@ -13,14 +13,13 @@
 
 namespace humhub\modules\onlyoffice\controllers;
 
+use humhub\components\Controller;
+use humhub\modules\file\libs\FileHelper;
+use humhub\modules\file\models\File;
+use humhub\modules\onlyoffice\Module;
+use humhub\modules\user\models\User;
 use Yii;
 use yii\web\HttpException;
-use humhub\modules\file\models\File;
-use humhub\modules\user\models\User;
-use humhub\components\Controller;
-use \humhub\components\Module;
-use humhub\modules\file\libs\FileHelper;
-use \Firebase\JWT\JWT;
 
 class BackendController extends Controller
 {
@@ -91,7 +90,7 @@ class BackendController extends Controller
             }
 
             try {
-                $ds = JWT::decode($token, $this->module->getJwtSecret(), array('HS256'));
+                $ds = $this->module->jwtDecode($token);
             } catch (\Exception $ex) {
                 throw new HttpException(403, 'Invalid JWT signature');
             }
@@ -116,7 +115,7 @@ class BackendController extends Controller
             }
 
             try {
-                $ds = JWT::decode($token, $this->module->getJwtSecret(), array('HS256'));
+                $ds = $this->module->jwtDecode($token);
             } catch (\Exception $ex) {
                 throw new HttpException(403, 'Invalid JWT signature');
             }
@@ -164,7 +163,7 @@ class BackendController extends Controller
             }
 
             try {
-                $ds = JWT::decode($token, $this->module->getJwtSecret(), array('HS256'));
+                $ds = $this->module->jwtDecode($token);
                 $data = isset($ds->payload) ? (array)$ds->payload : (array)$ds;
             } catch (\Exception $ex) {
                 throw new HttpException(403, 'Invalid JWT signature');

--- a/widgets/EditorWidget.php
+++ b/widgets/EditorWidget.php
@@ -13,19 +13,17 @@
 
 namespace humhub\modules\onlyoffice\widgets;
 
+use humhub\libs\Html;
+use humhub\modules\content\permissions\ManageContent;
+use humhub\modules\content\models\ContentContainer;
+use humhub\modules\file\libs\FileHelper;
+use humhub\modules\file\models\File;
+use humhub\modules\onlyoffice\Module;
+use humhub\modules\user\models\User;
+use humhub\widgets\JsWidget;
 use Yii;
 use yii\helpers\Url;
 use yii\web\HttpException;
-use humhub\modules\file\models\File;
-use humhub\modules\cfiles\models\File as cFile;
-use humhub\modules\cfiles\models\Folder as cFolder;
-use humhub\libs\Html;
-use humhub\modules\file\libs\FileHelper;
-use humhub\widgets\JsWidget;
-use humhub\modules\content\permissions\ManageContent;
-use humhub\modules\content\models\ContentContainer;
-use humhub\modules\user\models\User;
-use \Firebase\JWT\JWT;
 
 /**
  * Description of EditorWidget
@@ -147,6 +145,7 @@ class EditorWidget extends JsWidget
 
     protected function getConfig()
     {
+        /* @var Module $module */
         $module = Yii::$app->getModule('onlyoffice');
         $user = Yii::$app->user->getIdentity();
         $userGuid = null;
@@ -205,8 +204,7 @@ class EditorWidget extends JsWidget
         }
 
         if ($module->isJwtEnabled()) {
-            $token = JWT::encode($config, $module->getJwtSecret());
-            $config['token'] = $token;
+            $config['token'] = $module->jwtEncode($config);
         }
 
         return $config;


### PR DESCRIPTION
Issue:

```php
FEHLER Wed, 10 May 2023 18:32:19 +0200 ArgumentCountError
ArgumentCountError: Too few arguments to function Firebase\JWT\JWT::encode(), 2 passed in /srv/www/htdocs/doku2/modules/onlyoffice/Module.php on line 399 and at least 3 expected in /srv/humhub/protected/vendor/firebase/php-jwt/src/JWT.php:184
Stack trace:
#0 /srv/www/htdocs/doku2/modules/onlyoffice/Module.php(399): Firebase\JWT\JWT::encode()
#1 /srv/www/htdocs/doku2/modules/onlyoffice/controllers/AdminController.php(150): humhub\modules\onlyoffice\Module->generateHash()
#2 /srv/www/htdocs/doku2/modules/onlyoffice/controllers/AdminController.php(104): humhub\modules\onlyoffice\controllers\AdminController->checkConvertFile()
#3 /srv/www/htdocs/doku2/modules/onlyoffice/controllers/AdminController.php(75): humhub\modules\onlyoffice\controllers\AdminController->validation()
#4 [internal function]: humhub\modules\onlyoffice\controllers\AdminController->actionSave()
#5 /srv/humhub/protected/vendor/yiisoft/yii2/base/InlineAction.php(57): call_user_func_array()
#6 /srv/humhub/protected/vendor/yiisoft/yii2/base/Controller.php(178): yii\base\InlineAction->runWithParams()
#7 /srv/humhub/protected/vendor/yiisoft/yii2/base/Module.php(552): yii\base\Controller->runAction()
#8 /srv/humhub/protected/vendor/yiisoft/yii2/web/Application.php(103): yii\base\Module->runAction()
#9 /srv/humhub/protected/vendor/yiisoft/yii2/base/Application.php(384): yii\web\Application->handleRequest()
#10 /srv/www/htdocs/doku2/index.php(24): yii\base\Application->run()
#11 {main}
```

Old version:

![alg](https://github.com/humhub/humhub-internal/assets/6995524/447b8b48-c2d4-46ff-8f7d-9d611a078886)

after run `composer install` I see the method was updated:

![alf_after_update](https://github.com/humhub/humhub-internal/assets/6995524/0cab4a2d-8212-43f8-8856-1713711d9542)
