### PR TITLE
Refresh `onlyoffice_key` on soft deletion

### DIFF
--- a/config.php
+++ b/config.php
@@ -5,14 +5,16 @@
  *  http://www.onlyoffice.com
  */
 
+use humhub\modules\content\models\Content;
 use humhub\modules\file\handler\FileHandlerCollection;
+use humhub\modules\onlyoffice\Events;
 
 return [
     'id' => 'onlyoffice',
     'class' => 'humhub\modules\onlyoffice\Module',
     'namespace' => 'humhub\modules\onlyoffice',
     'events' => [
-        [FileHandlerCollection::className(), FileHandlerCollection::EVENT_INIT, ['humhub\modules\onlyoffice\Events', 'onFileHandlerCollection']],
+        [FileHandlerCollection::class, FileHandlerCollection::EVENT_INIT, [Events::class, 'onFileHandlerCollection']],
+        [Content::class, Content::EVENT_AFTER_SOFT_DELETE, [Events::class, 'onContentAfterSoftDelete']],
     ]
 ];
-?>

--- a/module.json
+++ b/module.json
@@ -5,9 +5,9 @@
     "keywords": [
         "office", "word", "excel", "presentation", "document collaboration", "online editors", "edit documents online", "edit word online", "edit presentation online"
     ],
-    "version": "3.0.0",
+    "version": "3.1.0",
     "humhub": {
-        "minVersion": "1.3"
+        "minVersion": "1.14"
     },
     "homepage": "https://www.onlyoffice.com",
     "authors": [


### PR DESCRIPTION
Steps to reproduce:

- Create a file called `test.docx` locally with content `Local created file`
- Go to file module, create a file with content `test.docx` using Onlyoffice with content `Oo created file`. Make sure to save this file in Oo. (Wait few seconds).
-  Delete newly created file `test.docx` in file module
- Upload locally created `yura.docx` and try to view it in Oo.  `Oo created file` is shown instead of `Local created file`.

This is because the `file.onlyoffice_key` is not reset on soft delete. Maybe we can do this in core, as workaround when column exist. 