### PR TITLE
Fix checking pdf onlyoffice form

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -250,7 +250,8 @@ class Module extends \humhub\components\Module
 
     public function getforceEditTypes()
     {
-        return explode(",", $this->settings->get('forceEditTypes'));
+        $forceEditTypes = $this->settings->get('forceEditTypes');
+        return $forceEditTypes === null || $forceEditTypes === '' ? [] : explode(',', $forceEditTypes);
     }
 
     public function getServerApiUrl(): string
@@ -514,7 +515,7 @@ class Module extends \humhub\components\Module
      */
     public function isOnlyofficeForm($file)
     {
-        if ($file === null) {
+        if (!$file instanceof File || !$file->store->has()) {
             return false;
         }
         if ($this->getDocumentType($file) !== self::DOCUMENT_TYPE_PDF) {
@@ -524,8 +525,7 @@ class Module extends \humhub\components\Module
         $limitDetect = 300;
         $onlyofficeFormMetaTag = 'ONLYOFFICEFORM';
 
-        $path = $file->getStoredFilePath() . 'file';
-        $content = file_get_contents($path, false, null, 0, $limitDetect);
+        $content = file_get_contents($file->store->get(), false, null, 0, $limitDetect);
 
         $indexFirst = strpos($content, "%\xCD\xCA\xD2\xA9\x0D");
         if ($indexFirst === false) {


### PR DESCRIPTION
Fix the error: `yii\base\ErrorException: file_get_contents(/srv/www/htdocs/humhub/uploads/file/5/8/5895a5bf-df44-4c47-9964-778665eefec/file): Failed to open stream: No such file or directory in /srv/www/htdocs/humhub/modules/onlyofce/Module.php:528`

- Use `$file->store->get()` instead of `$file->getStoredFilePath() . 'file'`,
- Check the file exists by `$file->store->has()` before run `file_get_contents()`.