### PR TITLE
Migration to Bootstrap 5 for HumHub 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.3.0
+- Migration to Bootstrap 5 for HumHub 1.18
+
 ## 3.2.0
 ## Added
 - default empty templates

--- a/module.json
+++ b/module.json
@@ -5,11 +5,11 @@
     "keywords": [
         "office", "word", "excel", "presentation", "document collaboration", "online editors", "edit documents online", "edit word online", "edit presentation online"
     ],
-    "version": "3.2.0",
+    "version": "3.3.0",
     "humhub": {
-        "minVersion": "1.3"
+        "minVersion": "1.18"
     },
-    "homepage": "https://www.onlyoffice.com",
+    "homepage": "https://github.com/ONLYOFFICE/onlyoffice-humhub",
     "authors": [
         {
             "email": "support@onlyoffice.com",

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -5,7 +5,7 @@
  *  http://www.onlyoffice.com
  */
 
-use yii\bootstrap\ActiveForm;
+use humhub\widgets\form\ActiveForm;
 use yii\helpers\Html;
 use yii\helpers\Url;
 use yii\web\View;
@@ -52,7 +52,7 @@ use yii\web\View;
                     'OnlyofficeModule.base',
                     '<strong>ONLYOFFICE Docs</strong> successfully connected! - Installed version: {version}',
                     ['version' => $model->instaledVersion]
-                ); ?> 
+                ); ?>
                 <p style = "color: #84be5e">
                     <?= Yii::t(
                         'OnlyofficeModule.base',
@@ -66,30 +66,30 @@ use yii\web\View;
         <div class="alert alert-danger invalid-server-url" role="alert" hidden></div>
 
         <?php $form = ActiveForm::begin(['id' => 'configure-form']); ?>
-        <div class="form-group">
+        <div class="mb-3">
             <?= $form->field($model, 'serverUrl'); ?>
             <?= $form->field($model, 'verifyPeerOff')->checkbox(); ?>
             <?= $form->field($model, 'forceSave')->checkbox(); ?>
             <?= $form->field($model, 'demoServer')->checkbox(); ?>
         </div>
 
-        <div class="form-group">
+        <div class="mb-3">
             <?= $form->field($model, 'jwtSecret'); ?>
         </div>
 
-        <div class="form-group">
+        <div class="mb-3">
             <?= $form->field($model, 'jwtHeader'); ?>
         </div>
 
-        <div class="form-group">
+        <div class="mb-3">
             <?= $form->field($model, 'internalServerUrl'); ?>
         </div>
 
-        <div class="form-group">
+        <div class="mb-3">
             <?= $form->field($model, 'storageUrl'); ?>
         </div>
 
-        <div class="form-group">
+        <div class="mb-3">
             <?= Html::activeLabel($model, 'customLabel', ['class' => 'control-label']); ?>
             <?= $form->field($model, 'chat')->checkbox(); ?>
             <?= $form->field($model, 'compactHeader')->checkbox(); ?>
@@ -98,7 +98,7 @@ use yii\web\View;
             <?= $form->field($model, 'compactToolbar')->checkbox(); ?>
         </div>
 
-        <div id="forceEditTypes" class="form-group">
+        <div id="forceEditTypes" class="mb-3">
             <?= Html::activeLabel($model, 'editLabel', ['class' => 'control-label']); ?>
             <br/>
             <?php foreach ($forceEditExt as $key => $ext) {
@@ -110,7 +110,7 @@ use yii\web\View;
             } ?>
         </div>
 
-        <div class="form-group">
+        <div class="mb-3">
             <?= Html::Button('Submit', ['id' => 'saveBtn', 'class' => 'btn btn-primary', 'data-ui-loader' => '']) ?>
         </div>
         <?php ActiveForm::end(); ?>
@@ -195,7 +195,7 @@ use yii\web\View;
                     url: "' . Url::to(["/onlyoffice/admin/save"]) . '",
                     cache: false,
                     type: "POST",
-                    data: { 
+                    data: {
                         "ConfigureForm": {
                             serverUrl: serverUrl,
                             verifyPeerOff: verifyPeerOff,

--- a/views/create/document.php
+++ b/views/create/document.php
@@ -5,41 +5,33 @@
  *  http://www.onlyoffice.com
  */
 
-use humhub\widgets\ActiveForm;
-use humhub\libs\Html;
+use humhub\helpers\Html;
+use humhub\modules\onlyoffice\assets\Assets;
+use humhub\widgets\modal\Modal;
 
-\humhub\modules\onlyoffice\assets\Assets::register($this);
-
-$modal = \humhub\widgets\ModalDialog::begin([
-            'header' => Yii::t('OnlyofficeModule.base', '<strong>Create</strong> document')
-        ])
+Assets::register($this);
 ?>
 
-<?php $form = ActiveForm::begin(); ?>
-
-<div class="modal-body">
-    <?= $form->field(
-        $model,
-        'fileName',
-        ['template' => '{label}<div class="input-group">{input}<div class="input-group-addon">' .
-            $model->extension . '</div></div>{hint}{error}'
-        ]
-    ); ?>
-    <?= $form->field($model, 'openFlag')->checkbox(); ?>
-
-    <?= $form->field($model, 'fid')->hiddenInput()->label(false); ?>
-</div>
-
-<div class="modal-footer">
-    <?= Html::submitButton(
+<?php $form = Modal::beginFormDialog([
+    'title' => Yii::t('OnlyofficeModule.base', '<strong>Create</strong> document'),
+    'footer' => Html::submitButton(
         'Save',
         ['data-action-click' => 'onlyoffice.createSubmit',
             'data-ui-loader' => '',
-            'class' => 'btn btn-primary'
-        ]
-    ); ?>
-</div>
+            'class' => 'btn btn-primary',
+        ],
+    ),
+]) ?>
 
-<?php ActiveForm::end(); ?>
+    <?= $form->field(
+        $model,
+        'fileName',
+        ['template' => '{label}<div class="input-group">{input}<div class="input-group-text">' .
+            $model->extension . '</div></div>{hint}{error}',
+        ],
+    ) ?>
+    <?= $form->field($model, 'openFlag')->checkbox() ?>
 
-<?php \humhub\widgets\ModalDialog::end(); ?>
+    <?= $form->field($model, 'fid')->hiddenInput()->label(false) ?>
+
+<?php Modal::endFormDialog() ?>

--- a/views/create/index.php
+++ b/views/create/index.php
@@ -5,63 +5,62 @@
  *  http://www.onlyoffice.com
  */
 
+use humhub\widgets\modal\Modal;
 use yii\helpers\Url;
 
-$modal = \humhub\widgets\ModalDialog::begin([
-            'header' => Yii::t('OnlyofficeModule.base', '<strong>Create</strong> document')
-        ])
 ?>
-<style>
 
-    .modal-dialog {
-        width: 800px;
-    }
-    .try-editor-list {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        height: 180px;
-    }
-    .try-editor-list li {
-        float: left;
-        cursor: pointer;
-        border:1px solid #EEE;
-        height: 150px;
-        padding: 12px;
-        margin: 25px;
-        width: 135px;
-    }
-    .try-editor-list li:hover {
-        background-color:#6FDBE8;
-    }
+<?php Modal::beginDialog([
+    'title' => Yii::t('OnlyofficeModule.base', '<strong>Create</strong> document'),
+    'size' => Modal::SIZE_LARGE,
+]) ?>
 
-    .try-editor {
-        background-color: transparent;
-        background-position: center 0;
-        background-repeat: no-repeat;
-        display: block;
-        font-size: 14px;
-        font-weight: bold;
-        height: 45px;
-        padding-top: 100px;
-        text-align: center;
-        text-decoration: none;
-    }    
-    .try-editor.document {
-        background-image: url("<?= $this->context->module->getPublishedUrl('/file_docx.png'); ?>");
-    }
-    .try-editor.spreadsheet {
-        background-image: url("<?= $this->context->module->getPublishedUrl('/file_xlsx.png'); ?>");
-    }
-    .try-editor.presentation {
-        background-image: url("<?= $this->context->module->getPublishedUrl('/file_pptx.png'); ?>");
-    }
-    .try-editor.form-template {
-        background-image: url("<?= $this->context->module->getPublishedUrl('/file_docxf.png'); ?>");
-    }
-</style>
-<div class="modal-body">
-    <br />
+    <style>
+        .try-editor-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            height: 180px;
+        }
+        .try-editor-list li {
+            float: left;
+            cursor: pointer;
+            border:1px solid #EEE;
+            height: 150px;
+            padding: 12px;
+            margin: 25px;
+            width: 135px;
+        }
+        .try-editor-list li:hover {
+            background-color:#6FDBE8;
+        }
+
+        .try-editor {
+            background-color: transparent;
+            background-position: center 0;
+            background-repeat: no-repeat;
+            display: block;
+            font-size: 14px;
+            font-weight: bold;
+            height: 45px;
+            padding-top: 100px;
+            text-align: center;
+            text-decoration: none;
+        }
+        .try-editor.document {
+            background-image: url("<?= $this->context->module->getPublishedUrl('/file_docx.png'); ?>");
+        }
+        .try-editor.spreadsheet {
+            background-image: url("<?= $this->context->module->getPublishedUrl('/file_xlsx.png'); ?>");
+        }
+        .try-editor.presentation {
+            background-image: url("<?= $this->context->module->getPublishedUrl('/file_pptx.png'); ?>");
+        }
+        .try-editor.form-template {
+            background-image: url("<?= $this->context->module->getPublishedUrl('/file_docxf.png'); ?>");
+        }
+    </style>
+
     <span class="try-descr">Please select a document type.</span>
     <br />
     <ul class="try-editor-list">
@@ -69,7 +68,7 @@ $modal = \humhub\widgets\ModalDialog::begin([
             <a class="try-editor document" data-action-click="ui.modal.load" data-action-url="
                 <?= Url::to([
                     'document',
-                    'extension' => 'docx'
+                    'extension' => 'docx',
                 ]); ?>">
                 Document
             </a>
@@ -78,7 +77,7 @@ $modal = \humhub\widgets\ModalDialog::begin([
             <a class="try-editor spreadsheet" data-action-click="ui.modal.load" data-action-url="
                 <?= Url::to([
                     'document',
-                    'extension' => 'xlsx'
+                    'extension' => 'xlsx',
                 ]); ?>">
                 Spreadsheet
             </a>
@@ -87,7 +86,7 @@ $modal = \humhub\widgets\ModalDialog::begin([
             <a class="try-editor presentation" data-action-click="ui.modal.load" data-action-url="
                 <?= Url::to([
                     'document',
-                    'extension' => 'pptx'
+                    'extension' => 'pptx',
                 ]); ?>">
                 Presentation
             </a>
@@ -96,11 +95,11 @@ $modal = \humhub\widgets\ModalDialog::begin([
             <a class="try-editor form-template" data-action-click="ui.modal.load" data-action-url="
                 <?= Url::to([
                     'document',
-                    'extension' => 'pdf'
+                    'extension' => 'pdf',
                 ]); ?>">
                 PDF form
             </a>
         </li>
     </ul>
-</div>
-<?php \humhub\widgets\ModalDialog::end(); ?>
+
+<?php Modal::endDialog() ?>

--- a/views/open/index.php
+++ b/views/open/index.php
@@ -1,38 +1,31 @@
 <?php
-
 /**
  *  Copyright (c) Ascensio System SIA 2024. All rights reserved.
  *  http://www.onlyoffice.com
  */
 
-use yii\web\View;
+use humhub\components\View;
+use humhub\modules\file\models\File;
+use humhub\modules\onlyoffice\widgets\EditorWidget;
+use humhub\widgets\modal\Modal;
 
+/**
+ * @var $file File
+ * @var $this View
+ */
+
+// Force modal full height
+$this->registerCss('#onlyoffice-modal .modal-content {height: calc(100vh - 90px); background-color:transparent; box-shadow: none;}');
 ?>
 
-<div class="modal-dialog animated fadeIn" style="width:96%">
-    <div class="modal-content onlyofficeModal" style="background-color:transparent;">
-        <?=
-        \humhub\modules\onlyoffice\widgets\EditorWidget::widget([
-            'file' => $file,
-            'mode' => $mode,
-            'restrict' => $restrict,
-            'anchor' => $anchor
-        ]);
-        ?>
-    </div>
-</div>
-
-<?php
-    View::registerJs('
-        window.onload = function (evt) {
-            setSize();
-        };
-        window.onresize = function (evt) {
-            setSize();
-        };
-        setSize();
-
-        function setSize() {
-            $(".onlyofficeModal").css("height", window.innerHeight - 110 + "px");
-        }
-    '); ?>
+<?php Modal::beginDialog([
+    'size' => Modal::SIZE_EXTRA_LARGE,
+    'closeButton' => false,
+]) ?>
+    <?= EditorWidget::widget([
+        'file' => $file,
+        'mode' => $mode,
+        'restrict' => $restrict,
+        'anchor' => $anchor,
+    ]) ?>
+<?php Modal::endDialog() ?>

--- a/widgets/EditorWidget.php
+++ b/widgets/EditorWidget.php
@@ -13,9 +13,9 @@
 
 namespace humhub\modules\onlyoffice\widgets;
 
-use humhub\libs\Html;
-use humhub\modules\content\permissions\ManageContent;
+use humhub\helpers\Html;
 use humhub\modules\content\models\ContentContainer;
+use humhub\modules\content\permissions\ManageContent;
 use humhub\modules\file\libs\FileHelper;
 use humhub\modules\file\models\File;
 use humhub\modules\onlyoffice\Module;

--- a/widgets/views/convert.php
+++ b/widgets/views/convert.php
@@ -5,33 +5,31 @@
  *  http://www.onlyoffice.com
  */
 
-use humhub\libs\Html;
-use humhub\widgets\ModalDialog;
+use humhub\helpers\Html;
+use humhub\modules\onlyoffice\assets\Assets;
+use humhub\widgets\modal\Modal;
+use humhub\widgets\modal\ModalButton;
 
-\humhub\modules\onlyoffice\assets\Assets::register($this);
+Assets::register($this);
 ?>
 
-<?php $modal = ModalDialog::begin(['header' => Yii::t('OnlyofficeModule.base', '<strong>Convert</strong> document')]) ?>
-<?= Html::beginTag('div', $options) ?>
+<?php Modal::beginDialog([
+    'title' => Yii::t('OnlyofficeModule.base', '<strong>Convert</strong> document'),
+    'footer' => ModalButton::cancel(Yii::t('base', 'Close')),
+]) ?>
 
-<div class="modal-body">
-    <span>
-        <?= Yii::t(
-            'OnlyofficeModule.base',
-            'Converting <strong>{oldFileName}</strong> to <strong>{newFileName}</strong>..',
-            ['oldFileName' => $file->fileName, 'newFileName' => $newName]
-        ); ?>
-    </span>
-    <br/>
-    <span id="oConvertMessage"></span>
+    <?= Html::beginTag('div', $options) ?>
 
-</div>
+        <span>
+            <?= Yii::t(
+                'OnlyofficeModule.base',
+                'Converting <strong>{oldFileName}</strong> to <strong>{newFileName}</strong>..',
+                ['oldFileName' => $file->fileName, 'newFileName' => $newName]
+            ); ?>
+        </span>
+        <br/>
+        <span id="oConvertMessage"></span>
 
-<div class="modal-footer">
-    <a href="#" data-modal-close class="btn btn-primary" data-action-click="close" data-ui-loader>
-        <?= Yii::t('OnlyofficeModule.base', 'Close'); ?>
-    </a>
-</div>
+    <?= Html::endTag('div'); ?>
 
-<?= Html::endTag('div'); ?>
-<?php ModalDialog::end(); ?>
+<?php Modal::endDialog() ?>

--- a/widgets/views/editor.php
+++ b/widgets/views/editor.php
@@ -5,9 +5,9 @@
  *  http://www.onlyoffice.com
  */
 
-use yii\helpers\Url;
-use humhub\libs\Html;
+use humhub\helpers\Html;
 use humhub\modules\onlyoffice\Module;
+use yii\helpers\Url;
 
 \humhub\modules\onlyoffice\assets\Assets::register($this);
 
@@ -31,31 +31,32 @@ if ($documentType === Module::DOCUMENT_TYPE_SPREADSHEET) {
     background-color:<?= $headerBackgroundColor; ?>;
     padding-top:7px;
     padding-right:7px">
-    <div class = "pull-right">
+    <div class = "float-end">
         <?php if ($mode === Module::OPEN_MODE_EDIT && !Yii::$app->user->isGuest) : ?>
-            <?= humhub\libs\Html::a(
+            <?= humhub\helpers\Html::a(
                 Yii::t('OnlyofficeModule.base', 'Share'),
                 '#',
-                ['class' => 'btn btn btn-default',
+                [
+                    'class' => 'btn btn btn-light',
                     'data-action-click' => 'share',
                     'data-action-block' => 'sync',
                     'data-action-url' => Url::to([
                         '/onlyoffice/share',
                         'guid' => $file->guid,
-                        'mode' => $mode
-                    ])
-                ]
-            ); ?>
+                        'mode' => $mode,
+                    ]),
+                ],
+            ) ?>
         <?php endif; ?>
-        <?= humhub\libs\Html::a(
+        <?= humhub\helpers\Html::a(
             Yii::t('OnlyofficeModule.base', 'Close'),
             '#',
-            ['class' => 'btn btn btn-default',
+            [
+                'class' => 'btn btn btn-light',
                 'data-ui-loader' => '',
-                'data-action-click' => 'close',
-                'data-action-block' => 'manual'
-            ]
-        ); ?>
+                'data-bs-dismiss' => 'modal',
+            ],
+        ) ?>
     </div>
 </div>
 <div id="iframeContainer"></div>

--- a/widgets/views/share.php
+++ b/widgets/views/share.php
@@ -5,70 +5,62 @@
  *  http://www.onlyoffice.com
  */
 
-use humhub\libs\Html;
-use humhub\widgets\ModalDialog;
+use humhub\helpers\Html;
+use humhub\widgets\modal\Modal;
+use humhub\widgets\modal\ModalButton;
 
 if (class_exists('humhub\assets\ClipboardJsAsset')) {
     humhub\assets\ClipboardJsAsset::register($this);
 }
 ?>
 
-<?php $modal = ModalDialog::begin() ?>
-<?= Html::beginTag('div', $options) ?>
+<?php Modal::beginDialog([
+    'title' => Yii::t('OnlyofficeModule.base', '<strong>Share</strong> document'),
+    'footer' => ModalButton::cancel(Yii::t('base', 'Close')),
+]) ?>
 
-<div class="modal-header">
-    <h4 class="modal-title" id="#onlyoffice-share-modal-title">
-        <?= Yii::t('OnlyofficeModule.base', '<strong>Share</strong> document'); ?>
-    </h4>
-</div>
-<div class="modal-body">
-    <?= Yii::t(
-        'OnlyofficeModule.base',
-        'You can simply share this document using a direct link.' .
-            'The user does not need an valid user account on the platform.'
-    ); ?>
-    <br/>
-    <br/>
+    <?= Html::beginTag('div', $options) ?>
 
-    <div class="checkbox" style="margin-left:-10px;">
-        <label>
-            <input type="checkbox" class="viewLinkCheckbox">
-            <?= Yii::t('OnlyofficeModule.base', 'Link for view only access'); ?>
-        </label>
-    </div>
-    <div class="form-group viewLinkInput" style="margin-top:6px">
-        <input type="text" class="form-control" value="<?= $viewLink; ?>">
-        <p class="help-block pull-right">
-            <a href="#" onClick="clipboard.writeText($('.viewLinkInput').find('input').val())">
-                <i class="fa fa-clipboard" aria-hidden="true"></i>
-                <?= Yii::t('OnlyofficeModule.base', 'Copy to clipboard'); ?>
-            </a>
-        </p>
-    </div>
+        <?= Yii::t(
+            'OnlyofficeModule.base',
+            'You can simply share this document using a direct link.' .
+                'The user does not need an valid user account on the platform.'
+        ); ?>
+        <br/>
+        <br/>
 
-    <div class="checkbox" style="margin-left:-10px;padding-top:12px">
-        <label>
-            <input type="checkbox" class="editLinkCheckbox">
-            <?= Yii::t('OnlyofficeModule.base', 'Link with enabled write access'); ?>
-        </label>
-    </div>
-    <div class="form-group editLinkInput"  style="margin-top:6px">
-        <input type="text" class="form-control" value="<?= $editLink; ?>">
-        <p class="help-block  pull-right">
-            <a href="#" onClick="clipboard.writeText($('.editLinkInput').find('input').val())">
-                <i class="fa fa-clipboard" aria-hidden="true"></i>
-                <?= Yii::t('OnlyofficeModule.base', 'Copy to clipboard'); ?>
-            </a>
-        </p>
-    </div>
+        <div class="checkbox" style="margin-left:-10px;">
+            <label>
+                <input type="checkbox" class="viewLinkCheckbox">
+                <?= Yii::t('OnlyofficeModule.base', 'Link for view only access'); ?>
+            </label>
+        </div>
+        <div class="mb-3 viewLinkInput" style="margin-top:6px">
+            <input type="text" class="form-control" value="<?= $viewLink; ?>">
+            <p class="form-text float-end">
+                <a href="#" onClick="clipboard.writeText($('.viewLinkInput').find('input').val())">
+                    <i class="fa fa-clipboard" aria-hidden="true"></i>
+                    <?= Yii::t('OnlyofficeModule.base', 'Copy to clipboard'); ?>
+                </a>
+            </p>
+        </div>
 
-</div>
+        <div class="checkbox" style="margin-left:-10px;padding-top:12px">
+            <label>
+                <input type="checkbox" class="editLinkCheckbox">
+                <?= Yii::t('OnlyofficeModule.base', 'Link with enabled write access'); ?>
+            </label>
+        </div>
+        <div class="mb-3 editLinkInput"  style="margin-top:6px">
+            <input type="text" class="form-control" value="<?= $editLink; ?>">
+            <p class="form-text  float-end">
+                <a href="#" onClick="clipboard.writeText($('.editLinkInput').find('input').val())">
+                    <i class="fa fa-clipboard" aria-hidden="true"></i>
+                    <?= Yii::t('OnlyofficeModule.base', 'Copy to clipboard'); ?>
+                </a>
+            </p>
+        </div>
 
-<div class="modal-footer">
-    <a href="#" data-modal-close class="btn btn-primary" data-ui-loader>
-        <?= Yii::t('OnlyofficeModule.base', 'Close'); ?>
-    </a>
-</div>
+    <?= Html::endTag('div'); ?>
 
-<?= Html::endTag('div'); ?>
-<?php ModalDialog::end(); ?>
+<?php Modal::endDialog() ?>


### PR DESCRIPTION
This PR allows the module to be compatible with the upcoming HumHub 1.18 version: https://github.com/humhub/humhub/pull/7236